### PR TITLE
fixed `url` string

### DIFF
--- a/scripts/southpark_corpus.R
+++ b/scripts/southpark_corpus.R
@@ -7,7 +7,7 @@ setwd("/Users/kaylinwalker/R/textmining_southpark/data/raw data")
 if(file.exists("all-seasons.csv")) {
      scripts <- read.csv("all-seasons.csv", stringsAsFactors=FALSE)
 } else { 
-     url <- "https://raw.github.com/BobAdamsEE/SouthParkData/master/All-seasons.csv"
+     url <- "https://raw.githubusercontent.com/BobAdamsEE/SouthParkData/master/All-seasons.csv"
      scripts <- download.file(url, "all-seasons.csv", method="curl")
      scripts <- read.csv("all-seasons.csv", stringsAsFactors=FALSE)
 }


### PR DESCRIPTION
The existing link resolves to the updated link in this PR. curl can't seem to download it so the script throws errors. This PR changes the data URL.

I found the bug while walking through the scripts to recreate your results after reading your post on HN. Cheers.
